### PR TITLE
ERP-98 - LB -> NS - Config - Standardize shipping method names across LB and NS

### DIFF
--- a/lib/netsuite/actions/get_select_value.rb
+++ b/lib/netsuite/actions/get_select_value.rb
@@ -20,6 +20,16 @@ module NetSuite
         ).call :get_select_value, :message => @options
       end
 
+      def request_body
+        type = @klass.to_s.split('::').last.sub(/[A-Z]/) { |m| m[0].downcase }
+
+        {
+          record: [
+            record_type: type
+          ]
+        }
+      end
+
       def success?
         @success ||= response_hash[:status][:@is_success] == 'true'
       end


### PR DESCRIPTION
When we try to get a list of values using the `get_select_values`
method, we're getting a missing method error for `request_body`.
- Add missing `request_body` method to `get_select_value` class
